### PR TITLE
修复bug：目标检测矩形框，默认是移动状态，如果不设置，则刚进入后，直接调整标注区域，会导致无法释放当前的鼠标状态

### DIFF
--- a/src/pages/Detection/index.tsx
+++ b/src/pages/Detection/index.tsx
@@ -33,7 +33,7 @@ const Page = () => {
   const [isLoad, setIsLoad] = useState<boolean>(false);
   const [otherSetting, setotherSetting] = useState();
   const [flags, setflags] = useState<boolean>(false);
-  const [preTools, setPreTools] = useState<string>('');
+  const [preTools, setPreTools] = useState<string>('mover');
   const [hideLabel, setHideLabel] = useState<number[]>([]);
   // const [onSelect, setOnSelect] = useState<Annotation>();
 


### PR DESCRIPTION
需要点左侧的矩形，然后再点移动，才可以释放鼠标状态。