### PR TITLE
取消直接滚动滚轮的放大缩小，效果太差，仅仅支持ctrl+滚轮形式

### DIFF
--- a/src/pages/Detection/index.tsx
+++ b/src/pages/Detection/index.tsx
@@ -485,11 +485,13 @@ const Page = () => {
   };
   const handleWheel = (event) => {
     const deta = event.deltaY;
-    if (deta > 0) {
-      scale.change(-0.1);
-    }
-    if (deta < 0) {
-      scale.change(0.1);
+    if (event.ctrlKey) {
+      if (deta > 0) {
+        scale.change(-0.05);
+      }
+      if (deta < 0) {
+        scale.change(0.05);
+      }
     }
   };
   const onHideLabel = (change: boolean, id: number) => {


### PR DESCRIPTION
同时，调小了一个滚动放大缩小的比率，效果更好